### PR TITLE
Fix default (stub) configuration

### DIFF
--- a/src/meteoalarm-card.ts
+++ b/src/meteoalarm-card.ts
@@ -76,18 +76,26 @@ export class MeteoalarmCard extends LitElement {
 
 	public static getStubConfig(hass: HomeAssistant, entities: string[]): Record<string, unknown> {
 		// Find fist entity that is supported by any integration
+		const ALLOWED_INTEGRATION_TYPES = [
+			MeteoalarmIntegrationEntityType.SingleEntity,
+			MeteoalarmIntegrationEntityType.CurrentExpected
+		 ];
+
 		for(const entity of entities) {
-			for(const integration of MeteoalarmCard.integrations) {
+			const integrations = MeteoalarmCard.integrations.filter((x) =>
+				ALLOWED_INTEGRATION_TYPES.includes(x.metadata.type)
+			);
+			for(const integration of integrations) {
 				if(integration.supports(hass.states[entity])) {
 					return {
-						entity: entity,
+						entities: { entity },
 						integration: integration.metadata.key
 					};
 				}
 			}
 		}
 		return {
-			entity: '',
+			entities: '',
 			integration: ''
 		};
 	}


### PR DESCRIPTION
2.0.0 introduced a bug where stub config won't be generated using `entities` and still uses pre-2.0 config. This PR fixes this bug. I've also gone ahead and excluded multiple entity integrations from the stub config.