### PR TITLE
Fix card scaling on very small sizes

### DIFF
--- a/src/meteoalarm-card.ts
+++ b/src/meteoalarm-card.ts
@@ -211,7 +211,6 @@ export class MeteoalarmCard extends LitElement {
 				const minFontSize = scaleHeadline ? MIN_FONT_SIZE : MAX_FONT_SIZE;
 				for (let fontSize = MAX_FONT_SIZE; fontSize >= minFontSize; fontSize--) {
 					const elementSize = getTextWidth(element.textContent!, getCanvasFont(regular, fontSize + 'px'));
-					if(regular.clientWidth <= 0) isSizeSet = true;
 					if(elementSize <= regular.clientWidth) {
 						this.setCardScaling(slide, size as any, fontSize);
 						isSizeSet = true;


### PR DESCRIPTION
Fixes: #157

Card sizes were incorrectly measured on very small sizes, this now works well:

![image](https://user-images.githubusercontent.com/23432278/222901250-2b4dc80a-0ad9-4392-9989-9a4b65bc35b7.png)

![image](https://user-images.githubusercontent.com/23432278/222901198-db8f3c64-fc21-4752-8962-58066a9e7430.png)
