### PR TITLE
Fix HA frotnent version check

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export class Utils {
 		if(!rawVersion) return false;
 		const year = rawVersion.substring(0,4);
 		const version = rawVersion.substring(4,6);
-		return Number(year) >= minYear && Number(version) >= minMonth;
+		return Number(year) >= minYear || (Number(year) >= minYear && Number(version) >= minMonth) ;
 	}
 
 	/**


### PR DESCRIPTION
MeteoalarmCard uses the frontend version for disabling and enabling some features on the fly. For example we tend to use newly added icons for some alerts. The dust warning alerts show `mdi:weather-dust` icon only in HA 2022.08 and newer. For older version we show `mdi:weather-windy`

![image](https://user-images.githubusercontent.com/23432278/228271569-c2a21101-6a53-464a-b848-26464c797cf4.png) ![image](https://user-images.githubusercontent.com/23432278/228271724-eca2142f-b1bc-4142-8b4e-340d6d0e94ab.png)

This check was broken since version 2023.01 and has caused some alerts to show old icons and printed invalid warnings to the console. This PR fixes this check.

(this is 2023.3.6)
![image](https://user-images.githubusercontent.com/23432278/228272320-6731297c-ed36-4ae1-bc17-975c8682082a.png)
