### PR TITLE
Add `overrides` to getLevelBySeverity (fix NINA severities)

### DIFF
--- a/src/integrations/nina.ts
+++ b/src/integrations/nina.ts
@@ -43,7 +43,10 @@ export default class NINA implements MeteoalarmIntegration {
 		return [{
 			event: MeteoalarmEventType.Unknown,
 			headline: headline,
-			level: Utils.getLevelBySeverity(severity)
+			level: Utils.getLevelBySeverity(
+				severity, {
+					'Moderate': MeteoalarmLevelType.Orange
+				})
 		}];
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,13 +21,21 @@ export class Utils {
 	 *
 	 * These are mostly rare cases like this one:
 	 * https://github.com/MrBartusek/MeteoalarmCard/issues/48
+	 *
+	 * @param severity severity as string (Minor, Moderate, Severe)
+	 * @param overrides optionally provide an list of overrides as object.
+	 * For example `{ "Moderate": MeteoalarmLevelType.Orange }`
+	 * @returns
 	 */
-	public static getLevelBySeverity(severity: string): MeteoalarmLevelType {
+	public static getLevelBySeverity(severity: string, overrides?: { [key: string]: MeteoalarmLevelType }): MeteoalarmLevelType {
+		if(overrides && overrides[severity]) {
+			return overrides[severity];
+		}
 		switch(severity) {
 			case 'Unknown':
 			case 'Minor':
-				return MeteoalarmLevelType.Yellow;
 			case 'Moderate':
+				return MeteoalarmLevelType.Yellow;
 			case 'Severe':
 				return MeteoalarmLevelType.Orange;
 			case 'High':


### PR DESCRIPTION
Fix: #163

Some integrations can use different names for different severities. For example, the `Moderate` severity is yellow in every other integration but, NINA uses it for orange alerts. For that reason, `getLevelBySeverity` now has the ability to accept `overrides` which NINA use for this severity.