### PR TITLE
Enviroment Canada advisory alerts support

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -116,7 +116,7 @@ export class BoilerplateCardEditor extends ScopedRegistryHost(LitElement) implem
 				${integration?.metadata.type == MeteoalarmIntegrationEntityType.Slots ? html`
 					${localize('editor.description.slots')}</p>
 				` : ''}
-				${integration?.metadata.type == MeteoalarmIntegrationEntityType.WarningWatchStatement ? html`
+				${integration?.metadata.type == MeteoalarmIntegrationEntityType.WarningWatchStatementAdvisory  ? html`
 					${localize('editor.description.warning_watch_statement')}</p>
 				` : ''}
 				${integration?.metadata.type == MeteoalarmIntegrationEntityType.SeparateEvents ? html`

--- a/src/integrations/env_canada.ts
+++ b/src/integrations/env_canada.ts
@@ -202,7 +202,7 @@ export default class EnvironmentCanada implements MeteoalarmIntegration {
 			{
 				type: EnvCanadaEntityType.Advisory,
 				en: 'Advisory',
-				fr: 'Avis De Gel'
+				fr: 'Avis De'
 			}
 		];
 	}
@@ -216,10 +216,11 @@ export default class EnvironmentCanada implements MeteoalarmIntegration {
 	private praseAlertName(alertName: string, type: EnvCanadaEntityType, isFrench: boolean) {
 		const prefixTranslation = this.entityTypeTranslation.find(t => t.type == type)!;
 		const prefix = isFrench ? prefixTranslation.fr : prefixTranslation.en;
+
 		if(!alertName.includes(prefix)) {
 			throw new Error(`Translated event prefix was not found in alert name '${prefix}' (isFrench=${isFrench})`);
 		}
-		alertName = alertName.replace(prefix, '') .trim();
+		alertName = alertName.replace(prefix, '').trim();
 
 		return this.eventTypes.find(e => {
 			return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,11 +48,8 @@ export enum MeteoalarmIntegrationEntityType {
   // Alerts in this integration are split across multiple (probably unlimited amount) of entities
   // each one contains one warning
   Slots = 2,
-  // Alerts in this integration are split across exactly 3 entities
-  // Warnings entity contains red warnings
-  // Watch entity contains orange warnings
-  // Statement entity contains yellow warnings
-  WarningWatchStatement = 3,
+  // Alerts in this integration are split across exactly 4 entities: warnings, watches, statements, advisories
+  WarningWatchStatementAdvisory  = 3,
   // Alerts in this integration are split across multiple entities, count is strictly specified
   // Each warning is dedicated for one entity kind
   SeparateEvents = 4


### PR DESCRIPTION
Fixes: #127

Add support for the fourth entity provided by Environment Canada, advisories are now shown as yellow alerts. This probably needs some information in the release so users can add their entity.