### PR TITLE
Add filters for event type and level

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ Here is what configuration options mean:
 | ---------------------- | --------- | ------------ | ------------------------------------------------------------------------------------ |
 | `type`                 | `string`  | **Required** | `custom:meteoalarm-card`                                                             |
 | `integration`          | `string`  | **Required** | Name of the integration. Available options are listed under [Supported integrations](#supported-integrations) |
-| `entities`             | `string`  | **Required** | Entity ID, a list of entity IDs or a list of entity objects.                         |
+| `entities`             | `array`   | **Required** | Entity ID, a list of entity IDs or a list of entity objects.                         |
 | `override_headline`    | `boolean` | `false`      | _[Only some integrations]_ Override headline proved by integration by generated one. |
 | `scaling_mode`         | `string`  | `headline_and_scale` | Headline scaling mode. See [scaling-mode.md](dosc/scaling-mode.md)           |
 | `disable_swiper`       | `boolean` | `false`      | _[Only some integrations]_ Disable slider when displaying multiple alerts, you may not see some important alerts. |
 | `hide_caption`         | `boolean` | `false`      | _[DWD only]_ Hide top-right caption when showing advance alerts.
 | `hide_when_no_warning` | `boolean` | `false`      | Hide the card when no warning is active. This works like a [conditional card](https://www.home-assistant.io/lovelace/conditional/). |
+| `ignored_levels`*      | `array`   | `[]`         | List of levels that will not be shown on the card. Possible values are: `Yellow`, `Orange` and `Red` |
+| `ignored_events`*      | `array`   | `[]`         | List of events that will not be shown on the card. Possible values are: `Nuclear Event`, `Hurricane`, `Tornado`,`Coastal Event`,`Tsunami`,`Forest Fire`,`Avalanches`,`Earthquake`,`Volcanic Activity`,`Flooding`,`Sea Event`,`Thunderstorms`,`Rain`,`Snow/Ice`,`High Temperature`,`Low Temperature`,`Dust`,`Wind`, `Fog`, `Air Quality` and `Unknown Event` |
+
+\* Not available thought visual editor
 
 Example configuration for [Meteoalarm](meteoalarm):
 

--- a/src/events-praser.ts
+++ b/src/events-praser.ts
@@ -2,7 +2,14 @@ import { HassEntity } from 'home-assistant-js-websocket';
 import { MeteoalarmData, MeteoalarmEventInfo, MeteoalarmLevelInfo } from './data';
 import { localize } from './localize/localize';
 import { PredefinedCards } from './predefined-cards';
-import { MeteoalarmAlert, MeteoalarmAlertKind, MeteoalarmAlertParsed, MeteoalarmEventType, MeteoalarmIntegration, MeteoalarmIntegrationEntityType, MeteoalarmLevelType } from './types';
+import {
+	MeteoalarmAlert,
+	MeteoalarmAlertKind,
+	MeteoalarmAlertParsed,
+	MeteoalarmEventType,
+	MeteoalarmIntegration,
+	MeteoalarmIntegrationEntityType
+} from './types';
 
 /**
  * This is the class that stands between integration and rendering code.

--- a/src/events-praser.ts
+++ b/src/events-praser.ts
@@ -2,7 +2,7 @@ import { HassEntity } from 'home-assistant-js-websocket';
 import { MeteoalarmData, MeteoalarmEventInfo, MeteoalarmLevelInfo } from './data';
 import { localize } from './localize/localize';
 import { PredefinedCards } from './predefined-cards';
-import { MeteoalarmAlert, MeteoalarmAlertKind, MeteoalarmAlertParsed, MeteoalarmEventType, MeteoalarmIntegration, MeteoalarmIntegrationEntityType } from './types';
+import { MeteoalarmAlert, MeteoalarmAlertKind, MeteoalarmAlertParsed, MeteoalarmEventType, MeteoalarmIntegration, MeteoalarmIntegrationEntityType, MeteoalarmLevelType } from './types';
 
 /**
  * This is the class that stands between integration and rendering code.
@@ -21,15 +21,18 @@ class EventsParser {
 		entities: HassEntity[],
 		disableSweeper = false,
 		overrideHeadline = false,
-		hideCaption = false
+		hideCaption = false,
+		ignoredLevels: string[] = [],
+		ignoredEvents: string[] = []
 	): MeteoalarmAlertParsed[] {
 		if(this.isAnyEntityUnavailable(entities)) {
 			return [ PredefinedCards.unavailableCard() ];
 		}
 		this.checkIfIntegrationSupportsEntities(entities);
 
-		const alerts = this.sortAlerts(this.graterAllAlerts(entities));
+		let alerts = this.sortAlerts(this.graterAllAlerts(entities));
 		this.validateAlert(alerts);
+		alerts = this.filterAlerts(alerts, ignoredLevels, ignoredEvents);
 
 		const result: MeteoalarmAlertParsed[] = [];
 		for(const alert of alerts) {
@@ -94,6 +97,25 @@ class EventsParser {
 			}
 		}
 		return alerts;
+	}
+
+	private filterAlerts(
+		alerts: MeteoalarmAlert[],
+		ignoredLevels: string[],
+		ignoredEvents: string[]
+	): MeteoalarmAlert[] {
+		if(ignoredEvents.length == 0 && ignoredLevels.length == 0) return alerts;
+		const result: MeteoalarmAlert[] = [];
+
+		for(const alert of alerts) {
+			const eventInfo = MeteoalarmData.events.find(e => e.type == alert.event)!;
+			const levelInfo = MeteoalarmData.levels.find(e => e.type == alert.level)!;
+			if(!ignoredEvents.includes(eventInfo.fullName) && !ignoredLevels.includes(levelInfo.fullName)) {
+				result.push(alert);
+			}
+		}
+
+		return result;
 	}
 
 	private sortAlerts(alertsInput: MeteoalarmAlert[]): MeteoalarmAlert[] {

--- a/src/integrations/burze_dzis_net.ts
+++ b/src/integrations/burze_dzis_net.ts
@@ -23,7 +23,15 @@ export default class BurzeDzisNet implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.SeparateEvents,
 			returnHeadline: true,
 			returnMultipleAlerts: true,
-			entitiesCount: 6
+			entitiesCount: 6,
+			monitoredConditions: [
+				MeteoalarmEventType.LowTemperature,
+				MeteoalarmEventType.HighTemperature,
+				MeteoalarmEventType.Rain,
+				MeteoalarmEventType.Thunderstorms,
+				MeteoalarmEventType.Tornado,
+				MeteoalarmEventType.Wind
+			]
 		};
 	}
 

--- a/src/integrations/dwd.ts
+++ b/src/integrations/dwd.ts
@@ -8,6 +8,7 @@ import {
 	MeteoalarmIntegrationMetadata,
 	MeteoalarmLevelType
 } from '../types';
+import { Utils } from '../utils';
 
 type DWDEntity = HassEntity & {
 	attributes: {
@@ -24,7 +25,8 @@ export default class DWD implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.CurrentExpected,
 			returnHeadline: true,
 			returnMultipleAlerts: true,
-			entitiesCount: 2
+			entitiesCount: 2,
+			monitoredConditions: Utils.convertEventTypesForMetadata(this.eventTypes)
 		};
 	}
 

--- a/src/integrations/env_canada.ts
+++ b/src/integrations/env_canada.ts
@@ -32,7 +32,8 @@ export default class EnvironmentCanada implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.WarningWatchStatementAdvisory,
 			returnHeadline: false,
 			returnMultipleAlerts: true,
-			entitiesCount: 4
+			entitiesCount: 4,
+			monitoredConditions: [...new Set(this.eventTypes.map(e => e.type))]
 		};
 	}
 

--- a/src/integrations/meteoalarm.ts
+++ b/src/integrations/meteoalarm.ts
@@ -34,7 +34,8 @@ export default class Meteoalarm implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.SingleEntity,
 			returnHeadline: true,
 			returnMultipleAlerts: false,
-			entitiesCount: 1
+			entitiesCount: 1,
+			monitoredConditions: this.eventTypes
 		};
 	}
 

--- a/src/integrations/meteofrance.ts
+++ b/src/integrations/meteofrance.ts
@@ -52,7 +52,18 @@ export default class MeteoFrance implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.SingleEntity,
 			returnHeadline: false,
 			returnMultipleAlerts: true,
-			entitiesCount: 1
+			entitiesCount: 1,
+			monitoredConditions: [
+				MeteoalarmEventType.Wind,
+				MeteoalarmEventType.Flooding,
+				MeteoalarmEventType.Thunderstorms,
+				MeteoalarmEventType.Flooding,
+				MeteoalarmEventType.SnowIce,
+				MeteoalarmEventType.HighTemperature,
+	 			MeteoalarmEventType.LowTemperature,
+				MeteoalarmEventType.Avalanches,
+				MeteoalarmEventType.CoastalEvent
+			]
 		};
 	}
 

--- a/src/integrations/nina.ts
+++ b/src/integrations/nina.ts
@@ -24,7 +24,10 @@ export default class NINA implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.Slots,
 			returnHeadline: true,
 			returnMultipleAlerts: true,
-			entitiesCount: 0
+			entitiesCount: 0,
+			monitoredConditions: [
+				MeteoalarmEventType.Unknown
+			]
 		};
 	}
 

--- a/src/integrations/weatheralerts.ts
+++ b/src/integrations/weatheralerts.ts
@@ -7,6 +7,7 @@ import {
 	MeteoalarmIntegrationMetadata,
 	MeteoalarmLevelType
 } from '../types';
+import { Utils } from '../utils';
 
 type WeatheralertsAlert = {
 	event: string,
@@ -29,7 +30,8 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 			type: MeteoalarmIntegrationEntityType.SingleEntity,
 			returnHeadline: true,
 			returnMultipleAlerts: true,
-			entitiesCount: 1
+			entitiesCount: 1,
+			monitoredConditions: Utils.convertEventTypesForMetadata(this.eventTypes)
 		};
 	}
 

--- a/src/meteoalarm-card.ts
+++ b/src/meteoalarm-card.ts
@@ -272,7 +272,9 @@ export class MeteoalarmCard extends LitElement {
 				this.entities,
 				this.config.disable_swiper,
 				this.config.override_headline,
-				this.config.hide_caption
+				this.config.hide_caption,
+				this.config.ignored_levels,
+				this.config.ignored_events
 			);
 
 			// Handle hide_when_no_warning

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export interface MeteoalarmCardConfig extends LovelaceCardConfig {
   hide_caption?: boolean;
   disable_swiper?: boolean;
   scaling_mode?: string;
+  ignored_events?: string[];
+  ignored_levels?: string[];
 
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface MeteoalarmIntegrationMetadata {
   entitiesCount:  number
   returnHeadline: boolean,
   returnMultipleAlerts: boolean,
+  monitoredConditions: MeteoalarmEventType[]
 }
 
 export enum MeteoalarmIntegrationEntityType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { MeteoalarmLevelType } from './types';
+import { MeteoalarmEventType, MeteoalarmLevelType } from './types';
 
 export class Utils {
 	/**
@@ -44,5 +44,14 @@ export class Utils {
 			default:
 				throw new Error(`[Utils.getLevelBySeverity] unknown event severity: "${severity}"`);
 		}
+	}
+
+	/**
+	 * Some integrations store their event mapping in key-value dict, this
+	 * function convert this list for metadata.monitoredConditions
+	 * @param evenTypes evenTypes dict
+	 */
+	public static convertEventTypesForMetadata(evenTypes: { [key: number | string]: MeteoalarmEventType }): MeteoalarmEventType[] {
+		return [...new Set(Object.values(evenTypes))];
 	}
 }


### PR DESCRIPTION
Fixes: #112

Users can now configure filters in YAML configuration to exclude specific events or levels

```yaml
type: custom:meteoalarm-card
integration: env_canada
entities:
  - entity: sensor.sundre_warnings
ignored_levels:
  - Yellow
ignored_events:
  - Air Quality
```