### PR TITLE
Add missing weatheralerts event types

### DIFF
--- a/src/integrations/weatheralerts.ts
+++ b/src/integrations/weatheralerts.ts
@@ -75,7 +75,11 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 			'Tropical Storm': MeteoalarmEventType.Hurricane,
 			'Hurricane': MeteoalarmEventType.Hurricane,
 			'Air Quality': MeteoalarmEventType.AirQuality,
-			'Rip Current': MeteoalarmEventType.CoastalEvent // https://github.com/MrBartusek/MeteoalarmCard/issues/183
+			'Special Weather': MeteoalarmEventType.Unknown,
+			'Rip Current': MeteoalarmEventType.CoastalEvent, // https://github.com/MrBartusek/MeteoalarmCard/issues/183
+			'High Surf': MeteoalarmEventType.CoastalEvent,
+			'Hazardous Seas': MeteoalarmEventType.SeaEvent,
+			'Beach Hazard': MeteoalarmEventType.CoastalEvent
 		};
 	}
 
@@ -83,6 +87,7 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 		// Event types from: https://www.weather.gov/lwx/WarningsDefined
 		return {
 			'Warning': MeteoalarmLevelType.Red,
+			'Statement': MeteoalarmLevelType.Orange,
 			'Watch': MeteoalarmLevelType.Orange,
 			'Advisory': MeteoalarmLevelType.Yellow,
 			'Alert': MeteoalarmLevelType.Yellow

--- a/src/integrations/weatheralerts.ts
+++ b/src/integrations/weatheralerts.ts
@@ -74,7 +74,8 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 			'Heat': MeteoalarmEventType.HighTemperature,
 			'Tropical Storm': MeteoalarmEventType.Hurricane,
 			'Hurricane': MeteoalarmEventType.Hurricane,
-			'Air Quality': MeteoalarmEventType.AirQuality
+			'Air Quality': MeteoalarmEventType.AirQuality,
+			'Rip Current': MeteoalarmEventType.CoastalEvent // https://github.com/MrBartusek/MeteoalarmCard/issues/183
 		};
 	}
 


### PR DESCRIPTION
Fix: #185

Add missing event types to weatheralerts 
- Special Weather
- High Surf
- Hazardous Seas
- Beach Hazard

Also, support the `Statements` as orange level