### PR TITLE
Fix "Special Weather" Alert Type Not Found

### DIFF
--- a/src/integrations/weatheralerts.ts
+++ b/src/integrations/weatheralerts.ts
@@ -75,7 +75,8 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 			'Tropical Storm': MeteoalarmEventType.Hurricane,
 			'Hurricane': MeteoalarmEventType.Hurricane,
 			'Air Quality': MeteoalarmEventType.AirQuality,
-			'Rip Current': MeteoalarmEventType.CoastalEvent // https://github.com/MrBartusek/MeteoalarmCard/issues/183
+			'Rip Current': MeteoalarmEventType.CoastalEvent, // https://github.com/MrBartusek/MeteoalarmCard/issues/183
+			'Special Weather': MeteoalarmEventType.Unknown
 		};
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,9 +49,9 @@ export class Utils {
 	/**
 	 * Some integrations store their event mapping in key-value dict, this
 	 * function convert this list for metadata.monitoredConditions
-	 * @param evenTypes evenTypes dict
+	 * @param eventTypes eventTypes dict
 	 */
-	public static convertEventTypesForMetadata(evenTypes: { [key: number | string]: MeteoalarmEventType }): MeteoalarmEventType[] {
-		return [...new Set(Object.values(evenTypes))];
+	public static convertEventTypesForMetadata(eventTypes: { [key: number | string]: MeteoalarmEventType }): MeteoalarmEventType[] {
+		return [...new Set(Object.values(eventTypes))];
 	}
 }


### PR DESCRIPTION
Fixes: #195

Sample Warning from NWS...
https://forecast.weather.gov/wwamap/wwatxtget.php?cwa=usa&wwa=Special%20Weather%20Statement

For some reason it is not listed on the nws definition page for alerts, https://www.weather.gov/lwx/WarningsDefined

I think this solution can be boiled down to being a thunderstorm but I dont have enough data to support that definitively. Thought about maybe parsing down the statement for what the alerts is stating but that seems overkill.