### PR TITLE
Add missing weatheralerts event types

### DIFF
--- a/src/integrations/weatheralerts.ts
+++ b/src/integrations/weatheralerts.ts
@@ -76,7 +76,11 @@ export default class Weatheralerts implements MeteoalarmIntegration {
 			'Hurricane': MeteoalarmEventType.Hurricane,
 			'Air Quality': MeteoalarmEventType.AirQuality,
 			'Rip Current': MeteoalarmEventType.CoastalEvent, // https://github.com/MrBartusek/MeteoalarmCard/issues/183
-			'Special Weather': MeteoalarmEventType.Unknown
+			'Special Weather': MeteoalarmEventType.Unknown,
+			'High Surf': MeteoalarmEventType.CoastalEvent,
+			'Hazardous Seas': MeteoalarmEventType.SeaEvent,
+			'Beach Hazard': MeteoalarmEventType.CoastalEvent
+
 		};
 	}
 


### PR DESCRIPTION
Fix: #197

Add missing event types to weatheralerts (again)

- High Surf
- Hazardous Seas
- Beach Hazard