### PR TITLE
Add smog warning type for Environment Canada

### DIFF
--- a/src/integrations/env_canada.ts
+++ b/src/integrations/env_canada.ts
@@ -124,6 +124,11 @@ export default class EnvironmentCanada implements MeteoalarmIntegration {
 				type: MeteoalarmEventType.Thunderstorms
 			},
 			{
+				en: 'Smog',
+				fr: 'Smog',
+				type: MeteoalarmEventType.AirQuality
+			},
+			{
 				en: 'Snowfall',
 				fr: 'Neige',
 				type: MeteoalarmEventType.SnowIce


### PR DESCRIPTION
There is currently a Smog Warning being issued by Environment Canada, which is not supported by the card.

This change adds support for this warning.

Here's the error I was getting before this change:
![error-screenshot](https://github.com/MrBartusek/MeteoalarmCard/assets/52664/1e2bd380-5a43-4056-986e-9374396e298d)

Here's what it looks like after this change:
![after-edit-screenshot](https://github.com/MrBartusek/MeteoalarmCard/assets/52664/4d1c199b-577d-4970-9d48-178283973ce2)

This works for English, but I was unable to figure out how to test it for French (there doesn't seem to be a language setting for the Environment Canada integration?).

The title of the French warning on the website is "Avertissement de smog en vigueur pour" so I'm guessing the warning would be "Avertissement De Smog" and this set the French to just "Smog" too, but that's just a guess.