### PR TITLE
DWD: Fix entity type detection when using translated `enity_id`

### DIFF
--- a/src/integrations/dwd.ts
+++ b/src/integrations/dwd.ts
@@ -144,13 +144,24 @@ export default class DWD implements MeteoalarmIntegration {
 	}
 
 	private getEntityKind(entity: HassEntity): MeteoalarmAlertKind | undefined {
-		if (entity.entity_id.split('_').includes('current')) {
+		const CURRENT_IDENTIFIERS = ['current', 'vorwahnstufe'];
+		const EXPECTED_IDENTIFIERS = ['advance', 'warnstufe'];
+
+		const friendlyName = entity.attributes.friendly_name || '';
+		const entityIdParts = entity.entity_id.split('_').map((p) => p.toLocaleLowerCase());
+		const friendlyNameParts = friendlyName?.split(' ').map((p) => p.toLocaleLowerCase());
+
+		if (
+			CURRENT_IDENTIFIERS.some(
+				(ident) => entityIdParts.includes(ident) || friendlyNameParts.includes(ident),
+			)
+		) {
 			return MeteoalarmAlertKind.Current;
-		} else if (entity.entity_id.split('_').includes('advance')) {
-			return MeteoalarmAlertKind.Expected;
-		} else if (entity.attributes.friendly_name?.split(' ').includes('Current')) {
-			return MeteoalarmAlertKind.Current;
-		} else if (entity.attributes.friendly_name?.split(' ').includes('Advance')) {
+		} else if (
+			EXPECTED_IDENTIFIERS.some(
+				(ident) => entityIdParts.includes(ident) || friendlyNameParts.includes(ident),
+			)
+		) {
 			return MeteoalarmAlertKind.Expected;
 		}
 		return undefined;

--- a/src/integrations/dwd.ts
+++ b/src/integrations/dwd.ts
@@ -144,8 +144,13 @@ export default class DWD implements MeteoalarmIntegration {
 	}
 
 	private getEntityKind(entity: HassEntity): MeteoalarmAlertKind | undefined {
-		const CURRENT_IDENTIFIERS = ['current', 'vorwahnstufe'];
-		const EXPECTED_IDENTIFIERS = ['advance', 'warnstufe'];
+		/**
+		 * Detecting only by English and German entity_id translations here is hardly
+		 * a good solution but, it covers 99% of use cases, should be improved in the
+		 * future
+		 */
+		const CURRENT_IDENTIFIERS = ['current', 'aktuelle'];
+		const EXPECTED_IDENTIFIERS = ['advance', 'vorwahnstufe'];
 
 		const friendlyName = entity.attributes.friendly_name || '';
 		const entityIdParts = entity.entity_id.split('_').map((p) => p.toLocaleLowerCase());


### PR DESCRIPTION
Fixes: #214

This PR fixes an issue with DWD integration that caused the `getEntityKind` function to fail when using translated `entity_id` and `friendly_name` to German. The function was expecting `sensor.dwd_weather_warnings_current_warning_level` and got `sensor.dwd_weather_warnings_aktuelle_warnstufe` since upstream integration was updated.

The solution here is to support both English and German translation keys. It covers 99% of use cases but it's not an ideal way to do this. 