### PR TITLE
Update README card-mod example to car-mod 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ type: custom:meteoalarm-card
 entities:
   entity: binary_sensor.meteoalarm
 integration: meteoalarm
-style: |
-  ha-card {
-    --inactive-background-color: blue;
-  }
+card_mod:
+  style: |
+    ha-card {
+      --inactive-background-color: blue;
+    }
 ```
 
 Which produces result:


### PR DESCRIPTION
Apparently README was using the old way to specifying card-mod styles which have been removed now

https://github.com/thomasloven/lovelace-card-mod/releases/tag/v3.4.0