### PR TITLE
Fix orange warning level color

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -97,7 +97,7 @@ export default css`
 	}
 
 	.event-orange {
-		background-color: var(--red-level-color);
+		background-color: var(--orange-level-background-color);
 	}
 
 	.event-yellow {


### PR DESCRIPTION
Fixes: #255

Since a couple of realises orange level warnings were shown as red warnings. This PR fixes that.

![image](https://github.com/MrBartusek/MeteoalarmCard/assets/23432278/1a68644c-b07f-4f0b-946c-eab7b89601b0)
